### PR TITLE
rm rng from public API

### DIFF
--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -11,8 +11,7 @@ fn main() {
 
 fn setup(mut commands: Commands) {
     // Spawn the shuffle bag.
-    let mut rng = rand::thread_rng();
-    commands.spawn(ShuffleBag::<usize>::try_new([1, 2, 3, 4, 5], &mut rng).unwrap());
+    commands.spawn(ShuffleBag::<usize>::try_new([1, 2, 3, 4, 5]).unwrap());
 
     // Spawn some UI text
     commands
@@ -29,6 +28,6 @@ fn pick(
     mut text: Single<&mut TextSpan, With<PickText>>,
 ) {
     // Pick a number from the shuffle bag. This is guaranteed to never pick the same number twice in a row.
-    let pick = shuffle_bag.pick(&mut rand::thread_rng());
-    text.0 = format!("\tLast pick: {}", pick);
+    let pick = shuffle_bag.pick();
+    text.0 = format!("\tLast pick: {pick}");
 }

--- a/examples/play_sound.rs
+++ b/examples/play_sound.rs
@@ -25,17 +25,13 @@ struct SoundAssets {
 impl FromWorld for SoundAssets {
     fn from_world(world: &mut World) -> Self {
         let assets = world.resource::<AssetServer>();
-        let mut rng = rand::thread_rng();
         Self {
-            steps: ShuffleBag::try_new(
-                vec![
-                    assets.load("step1.ogg"),
-                    assets.load("step2.ogg"),
-                    assets.load("step3.ogg"),
-                    assets.load("step4.ogg"),
-                ],
-                &mut rng,
-            )
+            steps: ShuffleBag::try_new(vec![
+                assets.load("step1.ogg"),
+                assets.load("step2.ogg"),
+                assets.load("step3.ogg"),
+                assets.load("step4.ogg"),
+            ])
             .unwrap(),
         }
     }
@@ -48,9 +44,8 @@ fn setup(mut commands: Commands) {
 }
 
 fn play_sound(mut commands: Commands, mut sound_assets: ResMut<SoundAssets>) {
-    let mut rng = rand::thread_rng();
     // Pick a sound from the shuffle bag. This is guaranteed to never pick the same sound twice in a row.
-    let sound = sound_assets.steps.pick(&mut rng);
+    let sound = sound_assets.steps.pick();
 
     // Spawn an audio player that plays the sound and despawns when it finishes.
     commands.spawn((AudioPlayer::new(sound.clone()), PlaybackSettings::DESPAWN));

--- a/examples/weighted.rs
+++ b/examples/weighted.rs
@@ -17,23 +17,18 @@ enum DamageModifier {
 
 fn setup(mut commands: Commands) {
     // Spawn the shuffle bag.
-    let mut rng = rand::thread_rng();
-
     commands.spawn(
-        ShuffleBag::try_new(
-            [
-                DamageModifier::CriticalHit,
-                DamageModifier::CriticalHit,
-                DamageModifier::Normal,
-                DamageModifier::Normal,
-                DamageModifier::Normal,
-                DamageModifier::Normal,
-                DamageModifier::Normal,
-                DamageModifier::Minor,
-                DamageModifier::Minor,
-            ],
-            &mut rng,
-        )
+        ShuffleBag::try_new([
+            DamageModifier::CriticalHit,
+            DamageModifier::CriticalHit,
+            DamageModifier::Normal,
+            DamageModifier::Normal,
+            DamageModifier::Normal,
+            DamageModifier::Normal,
+            DamageModifier::Normal,
+            DamageModifier::Minor,
+            DamageModifier::Minor,
+        ])
         .unwrap(),
     );
 
@@ -52,11 +47,11 @@ fn pick(
     mut text: Single<&mut TextSpan, With<PickText>>,
 ) {
     // Pick a number from the shuffle bag. This is guaranteed to never pick the same number twice in a row.
-    let pick = shuffle_bag.pick(&mut rand::thread_rng());
+    let pick = shuffle_bag.pick();
     let damage = match pick {
         DamageModifier::CriticalHit => "20 (Critical hit!)",
         DamageModifier::Normal => "10",
         DamageModifier::Minor => "8",
     };
-    text.0 = format!("\tLast pick: {}", damage);
+    text.0 = format!("\tLast pick: {damage}");
 }

--- a/readme.md
+++ b/readme.md
@@ -19,9 +19,8 @@ Using a shuffle bag is really simple. You just initialize it with some contents 
 use bevy::prelude::*;
 use bevy_shuffle_bag::ShuffleBag;
 
-let mut rng = rand::thread_rng();
-let mut treasure_chest = ShuffleBag::try_new(["gold", "armor", "sword"], &mut rng).unwrap();
-let loot = treasure_chest.pick(&mut rng);
+let mut treasure_chest = ShuffleBag::try_new(["gold", "armor", "sword"]).unwrap();
+let loot = treasure_chest.pick();
 println!("I just picked up a {loot}!");
 ```
 
@@ -56,7 +55,6 @@ struct SoundAssets {
 impl FromWorld for SoundAssets {
     fn from_world(world: &mut World) -> Self {
         let assets = world.resource::<AssetServer>();
-        let mut rng = rand::thread_rng();
         Self {
             steps: ShuffleBag::try_new(
                 vec![
@@ -65,7 +63,6 @@ impl FromWorld for SoundAssets {
                     assets.load("step3.ogg"),
                     assets.load("step4.ogg"),
                 ],
-                &mut rng,
             )
             .unwrap(),
         }
@@ -73,9 +70,8 @@ impl FromWorld for SoundAssets {
 }
 
 fn play_sound(mut commands: Commands, mut sound_assets: ResMut<SoundAssets>) {
-    let mut rng = rand::thread_rng();
     // Pick a sound from the shuffle bag. This is guaranteed to never pick the same sound twice in a row.
-    let sound = sound_assets.steps.pick(&mut rng);
+    let sound = sound_assets.steps.pick();
 
     // Spawn an audio player that plays the sound and despawns when it finishes.
     commands.spawn((AudioPlayer::new(sound.clone()), PlaybackSettings::DESPAWN));


### PR DESCRIPTION
I believe guarantee of never repeat holds the same without the need to pass rng aroung since underneath it's the same thread local instance of Rng.